### PR TITLE
fixed mplayer streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ python read.py bowsers-castle.mp4
 ```
 
 # To use with streaming
+You need `ffmpeg` installed to read from streams.
 nginx has a nice rtmp server that can allow redirecting and incoming streams.
 
 Setup nginx with `brew` and setup a config
@@ -71,5 +72,6 @@ mplayer rtmp://127.0.0.1:1935/castle/bowsers-castle.mp4
 
 Read from the stream:
 ```
+brew install ffmpeg
 python read.py rtmp://127.0.0.1:1935/castle/bowsers-castle.mp4
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Better README coming soon...
+Best Mario Kart Wii CV EVER
 
 # OSX Install
 ## Prereqs
@@ -38,7 +38,7 @@ rtmp {
                 listen 1935;
                 chunk_size 4096;
                 application castle {
-                        play /path/to/mario-kart/bowsers-castle.mp4;
+                        play /path/to/mario-kart;
                 }
         }
 }
@@ -56,8 +56,7 @@ nginx -s stop
 ```
 
 Make sure you can watch the video:
-... this doesn't work yet
 ```
 brew install mplayer
-mplayer rtmp://localhost:1935/castle -framedrop
+mplayer rtmp://127.0.0.1:1935/castle/bowsers-castle.mp4
 ```

--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@ Best Mario Kart Wii CV EVER
 
 # OSX Install
 ## Prereqs
-Install brew
-Install python virtualenv
+Install:
+  - [brew](http://brew.sh/)
+  - python [virtualenv](https://virtualenv.pypa.io/en/latest/)
 
 ## Installing
 
-brew packages...
+Use `brew` to install opencv packages
 ```
-brew install nginx-full --with-rtmp-module
-brew install
 brew tap homebrew/science
 brew install opencv
 ```
@@ -30,8 +29,17 @@ Sample movies
 ./getVideos.sh
 ```
 
-Setup nginx
+Run the program
 ```
+python read.py bowsers-castle.mp4
+```
+
+# To use with streaming
+nginx has a nice rtmp server that can allow redirecting and incoming streams.
+
+Setup nginx with `brew` and setup a config
+```
+brew install nginx-full --with-rtmp-module
 cat <<EOF > /usr/local/etc/nginx/servers/kart.conf
 rtmp {
         server {
@@ -59,4 +67,9 @@ Make sure you can watch the video:
 ```
 brew install mplayer
 mplayer rtmp://127.0.0.1:1935/castle/bowsers-castle.mp4
+```
+
+Read from the stream:
+```
+python read.py rtmp://127.0.0.1:1935/castle/bowsers-castle.mp4
 ```


### PR DESCRIPTION
this at least has nginx streaming files to mplayer.

running `python read.py rtpm://localhost:1935/castle/bowsers-castle.mp4` doesn't see to work though.
